### PR TITLE
Fix markdown in post excerpt

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,9 +20,9 @@ tagline:
     {{ post.content }}
     {% else %}
     {% if post.shortinfo %}
-    {{ post.shortinfo }}
+    {{ post.shortinfo|markdownify }}
     {% elsif post.description %}
-    {{ post.description }}
+    {{ post.description|markdownify }}
     {% else %}
     {{ post.excerpt }}
     {% endif %}


### PR DESCRIPTION
This (hopefully) fixes a minor bug in the home page by _markdownifying_ `description` and/or `shortinfo` strings:

![2018-07-11 09 33 36](https://user-images.githubusercontent.com/4732915/42571429-7f7ac6ec-84ed-11e8-856a-d9a92d6b45cd.jpg)
